### PR TITLE
Support escaping characters in keys

### DIFF
--- a/dist/amd/java.properties.js
+++ b/dist/amd/java.properties.js
@@ -5,9 +5,9 @@ define(['exports'], function (exports) {
         value: true
     });
     exports.propertiesToObject = propertiesToObject;
-
     function compose() {
         var fns = arguments;
+
         return function (result) {
             for (var i = fns.length - 1; i > -1; i--) {
                 result = fns[i].call(this, result);
@@ -18,47 +18,103 @@ define(['exports'], function (exports) {
     }
 
     function assignProperty(obj, path, value) {
-        var props = path.split('.');
+        var props = splitEscaped(path, '.');
         var key = props.pop();
         obj = props.reduce(function (newObj, prop) {
             if (!newObj[prop]) {
                 newObj[prop] = {};
             }
-
             return newObj[prop];
         }, obj);
+
         obj[key] = value;
     }
 
+    /**
+     * Split a string using a separator, if not preceded by a backslash.
+     * For simplicity, this does not correctly handle two preceding backslashes
+     * @param src {String} value to parse
+     * @param separator {String} single character separator
+     * @returns []
+     */
+    function splitEscaped(src, separator) {
+        var escapeFlag = false,
+            token = '',
+            result = [];
+        src.split('').forEach(function (letter) {
+            if (escapeFlag) {
+                token += letter;
+                escapeFlag = false;
+            } else if (letter === '\\') {
+                escapeFlag = true;
+            } else if (letter === separator) {
+                result.push(token);
+                token = '';
+            } else {
+                token += letter;
+            }
+        });
+        if (token.length > 0) {
+            result.push(token);
+        }
+        return result;
+    }
+
+    /**
+     * Tries to parse the value to a primitive type. It converts "true" and "false" to a boolean, and "2" to a number.
+     * @param value {String} value to parse
+     * @returns {Boolean|Number|String} parsed value
+     */
     function parseValue(value) {
         if (['true', 'false'].indexOf(value) !== -1) {
             return value === 'true';
         }
-
+        // is it float parsable?
         var parsed = parseFloat(value);
-
         if (!isNaN(parsed)) {
             return parsed;
         }
-
         return value;
     }
 
+    /**
+     * Validates whether the line is a comment (prefixed by # or !)
+     * @param line {String} the line
+     * @returns {Boolean} whether the line is a comment
+     */
     function isLineComment(line) {
         return (/^\s*(\#|\!|$)/.test(line)
         );
     }
 
+    /**
+     * Validates whether the line has continuation character (backslash) at end
+     * @param line {String} the line
+     * @returns {Boolean} whether the line is continued on the next line
+     */
     function isLineContinued(line) {
         return (/(\\\\)*\\$/.test(line)
         );
     }
 
+    /**
+     * Parses the line to a key and value
+     * @param line {String} the line
+     * @returns {Array} array with following structure: [line, key, value]
+     */
     function parseLine(line) {
         return (/^\s*((?:[^\s:=\\]|\\.)+)\s*[:=\s]\s*(.*)$/.exec(line)
         );
     }
 
+    /**
+     * Makes a deep structured object from a shallow object with dot-separated keys:
+     *   { "key.with.nesting": "value" }
+     *   becomes:
+     *   { "key": { "with": { "nesting": "value" } } }
+     * @param obj
+     * @returns {{}}
+     */
     function makeDeepStructure(obj) {
         return Object.keys(obj).reduce(function (nested, key) {
             assignProperty(nested, key, obj[key]);
@@ -66,47 +122,68 @@ define(['exports'], function (exports) {
         }, {});
     }
 
+    /**
+     * Combines lines which end with a backslash with the next line
+     * @param lines {String[]}
+     * @returns {String[]}
+     */
     function combineMultiLines(lines) {
         return lines.reduce(function (acc, cur) {
             var line = acc[acc.length - 1];
-
             if (acc.length && isLineContinued(line)) {
                 acc[acc.length - 1] = line.replace(/\\$/, '');
                 acc[acc.length - 1] += cur;
             } else {
                 acc.push(cur);
             }
-
             return acc;
         }, []);
     }
 
+    /**
+     * Removes leading white-space of every line
+     * @param lines {String[]}
+     * @returns {String[]}
+     */
     function removeLeadingWhitespace(lines) {
         return lines.map(function (line) {
             return line.replace(/^\s*/, '');
-        });
+        }); // remove space at start of line
     }
 
+    /**
+     * Filters out the comment lines
+     * @param lines {String[]}
+     * @returns {String[]}
+     */
     function filterOutComments(lines) {
         return lines.filter(function (line) {
             return !isLineComment(line);
         });
     }
 
+    /**
+     * Parses the lines add adds the key-values to the return object
+     * @param lines {String[]}
+     * @returns {{}} the parsed key-value pairs
+     */
     function parseLines(lines) {
         var propertyMap = {};
         lines.forEach(function (line) {
             var parsed = parseLine(line);
-
             if (!parsed) {
                 throw new Error('Cannot parse line: ', line);
             }
-
             propertyMap[parsed[1]] = parsed[2];
         });
         return propertyMap;
     }
 
+    /**
+     * Loops over the object values and tries to parse them to a native value.
+     * @param obj
+     * @returns {Object} the same object as the argument
+     */
     function parseValues(obj) {
         Object.keys(obj).forEach(function (key) {
             obj[key] = parseValue(obj[key]);
@@ -114,6 +191,11 @@ define(['exports'], function (exports) {
         return obj;
     }
 
+    /**
+     * Makes an array of strings from a string containing return-characters.
+     * @param str
+     * @returns {Array} array of lines
+     */
     function makeLines(str) {
         return str.split(/\r?\n/);
     }

--- a/dist/cjs/java.properties.js
+++ b/dist/cjs/java.properties.js
@@ -17,7 +17,7 @@ function compose() {
 }
 
 function assignProperty(obj, path, value) {
-    var props = path.split('.');
+    var props = splitEscaped(path, '.');
     var key = props.pop();
     obj = props.reduce(function (newObj, prop) {
         if (!newObj[prop]) {
@@ -30,6 +30,36 @@ function assignProperty(obj, path, value) {
 }
 
 /**
+ * Split a string using a separator, if not preceded by a backslash.
+ * For simplicity, this does not correctly handle two preceding backslashes
+ * @param src {String} value to parse
+ * @param separator {String} single character separator
+ * @returns []
+ */
+function splitEscaped(src, separator) {
+    var escapeFlag = false,
+        token = '',
+        result = [];
+    src.split('').forEach(function (letter) {
+        if (escapeFlag) {
+            token += letter;
+            escapeFlag = false;
+        } else if (letter === '\\') {
+            escapeFlag = true;
+        } else if (letter === separator) {
+            result.push(token);
+            token = '';
+        } else {
+            token += letter;
+        }
+    });
+    if (token.length > 0) {
+        result.push(token);
+    }
+    return result;
+}
+
+/**
  * Tries to parse the value to a primitive type. It converts "true" and "false" to a boolean, and "2" to a number.
  * @param value {String} value to parse
  * @returns {Boolean|Number|String} parsed value
@@ -38,7 +68,7 @@ function parseValue(value) {
     if (['true', 'false'].indexOf(value) !== -1) {
         return value === 'true';
     }
-    // is it float parseble?
+    // is it float parsable?
     var parsed = parseFloat(value);
     if (!isNaN(parsed)) {
         return parsed;

--- a/dist/systemjs/main.js
+++ b/dist/systemjs/main.js
@@ -1,10 +1,12 @@
 'use strict';
 
 System.register([], function (_export, _context) {
-    var pToO;
+    "use strict";
 
+    var pToO;
     function compose() {
         var fns = arguments;
+
         return function (result) {
             for (var i = fns.length - 1; i > -1; i--) {
                 result = fns[i].call(this, result);
@@ -15,47 +17,103 @@ System.register([], function (_export, _context) {
     }
 
     function assignProperty(obj, path, value) {
-        var props = path.split('.');
+        var props = splitEscaped(path, '.');
         var key = props.pop();
         obj = props.reduce(function (newObj, prop) {
             if (!newObj[prop]) {
                 newObj[prop] = {};
             }
-
             return newObj[prop];
         }, obj);
+
         obj[key] = value;
     }
 
+    /**
+     * Split a string using a separator, if not preceded by a backslash.
+     * For simplicity, this does not correctly handle two preceding backslashes
+     * @param src {String} value to parse
+     * @param separator {String} single character separator
+     * @returns []
+     */
+    function splitEscaped(src, separator) {
+        var escapeFlag = false,
+            token = '',
+            result = [];
+        src.split('').forEach(function (letter) {
+            if (escapeFlag) {
+                token += letter;
+                escapeFlag = false;
+            } else if (letter === '\\') {
+                escapeFlag = true;
+            } else if (letter === separator) {
+                result.push(token);
+                token = '';
+            } else {
+                token += letter;
+            }
+        });
+        if (token.length > 0) {
+            result.push(token);
+        }
+        return result;
+    }
+
+    /**
+     * Tries to parse the value to a primitive type. It converts "true" and "false" to a boolean, and "2" to a number.
+     * @param value {String} value to parse
+     * @returns {Boolean|Number|String} parsed value
+     */
     function parseValue(value) {
         if (['true', 'false'].indexOf(value) !== -1) {
             return value === 'true';
         }
-
+        // is it float parsable?
         var parsed = parseFloat(value);
-
         if (!isNaN(parsed)) {
             return parsed;
         }
-
         return value;
     }
 
+    /**
+     * Validates whether the line is a comment (prefixed by # or !)
+     * @param line {String} the line
+     * @returns {Boolean} whether the line is a comment
+     */
     function isLineComment(line) {
         return (/^\s*(\#|\!|$)/.test(line)
         );
     }
 
+    /**
+     * Validates whether the line has continuation character (backslash) at end
+     * @param line {String} the line
+     * @returns {Boolean} whether the line is continued on the next line
+     */
     function isLineContinued(line) {
         return (/(\\\\)*\\$/.test(line)
         );
     }
 
+    /**
+     * Parses the line to a key and value
+     * @param line {String} the line
+     * @returns {Array} array with following structure: [line, key, value]
+     */
     function parseLine(line) {
         return (/^\s*((?:[^\s:=\\]|\\.)+)\s*[:=\s]\s*(.*)$/.exec(line)
         );
     }
 
+    /**
+     * Makes a deep structured object from a shallow object with dot-separated keys:
+     *   { "key.with.nesting": "value" }
+     *   becomes:
+     *   { "key": { "with": { "nesting": "value" } } }
+     * @param obj
+     * @returns {{}}
+     */
     function makeDeepStructure(obj) {
         return Object.keys(obj).reduce(function (nested, key) {
             assignProperty(nested, key, obj[key]);
@@ -63,47 +121,68 @@ System.register([], function (_export, _context) {
         }, {});
     }
 
+    /**
+     * Combines lines which end with a backslash with the next line
+     * @param lines {String[]}
+     * @returns {String[]}
+     */
     function combineMultiLines(lines) {
         return lines.reduce(function (acc, cur) {
             var line = acc[acc.length - 1];
-
             if (acc.length && isLineContinued(line)) {
                 acc[acc.length - 1] = line.replace(/\\$/, '');
                 acc[acc.length - 1] += cur;
             } else {
                 acc.push(cur);
             }
-
             return acc;
         }, []);
     }
 
+    /**
+     * Removes leading white-space of every line
+     * @param lines {String[]}
+     * @returns {String[]}
+     */
     function removeLeadingWhitespace(lines) {
         return lines.map(function (line) {
             return line.replace(/^\s*/, '');
-        });
+        }); // remove space at start of line
     }
 
+    /**
+     * Filters out the comment lines
+     * @param lines {String[]}
+     * @returns {String[]}
+     */
     function filterOutComments(lines) {
         return lines.filter(function (line) {
             return !isLineComment(line);
         });
     }
 
+    /**
+     * Parses the lines add adds the key-values to the return object
+     * @param lines {String[]}
+     * @returns {{}} the parsed key-value pairs
+     */
     function parseLines(lines) {
         var propertyMap = {};
         lines.forEach(function (line) {
             var parsed = parseLine(line);
-
             if (!parsed) {
                 throw new Error('Cannot parse line: ', line);
             }
-
             propertyMap[parsed[1]] = parsed[2];
         });
         return propertyMap;
     }
 
+    /**
+     * Loops over the object values and tries to parse them to a native value.
+     * @param obj
+     * @returns {Object} the same object as the argument
+     */
     function parseValues(obj) {
         Object.keys(obj).forEach(function (key) {
             obj[key] = parseValue(obj[key]);
@@ -111,24 +190,27 @@ System.register([], function (_export, _context) {
         return obj;
     }
 
+    /**
+     * Makes an array of strings from a string containing return-characters.
+     * @param str
+     * @returns {Array} array of lines
+     */
     function makeLines(str) {
         return str.split(/\r?\n/);
+    }function propertiesToObject(propertiesFile) {
+        if (typeof propertiesFile !== 'string') {
+            throw new Error('Cannot parse java-properties when it is not a string');
+        }
+
+        return pToO(propertiesFile);
     }
+
+    _export('propertiesToObject', propertiesToObject);
 
     return {
         setters: [],
         execute: function () {
             pToO = compose(makeDeepStructure, parseValues, parseLines, combineMultiLines, filterOutComments, removeLeadingWhitespace, makeLines);
-
-            function propertiesToObject(propertiesFile) {
-                if (typeof propertiesFile !== 'string') {
-                    throw new Error('Cannot parse java-properties when it is not a string');
-                }
-
-                return pToO(propertiesFile);
-            }
-
-            _export('propertiesToObject', propertiesToObject);
 
             _export('default', propertiesToObject);
         }

--- a/dist/umd/java.properties.js
+++ b/dist/umd/java.properties.js
@@ -17,9 +17,9 @@
         value: true
     });
     exports.propertiesToObject = propertiesToObject;
-
     function compose() {
         var fns = arguments;
+
         return function (result) {
             for (var i = fns.length - 1; i > -1; i--) {
                 result = fns[i].call(this, result);
@@ -30,47 +30,103 @@
     }
 
     function assignProperty(obj, path, value) {
-        var props = path.split('.');
+        var props = splitEscaped(path, '.');
         var key = props.pop();
         obj = props.reduce(function (newObj, prop) {
             if (!newObj[prop]) {
                 newObj[prop] = {};
             }
-
             return newObj[prop];
         }, obj);
+
         obj[key] = value;
     }
 
+    /**
+     * Split a string using a separator, if not preceded by a backslash.
+     * For simplicity, this does not correctly handle two preceding backslashes
+     * @param src {String} value to parse
+     * @param separator {String} single character separator
+     * @returns []
+     */
+    function splitEscaped(src, separator) {
+        var escapeFlag = false,
+            token = '',
+            result = [];
+        src.split('').forEach(function (letter) {
+            if (escapeFlag) {
+                token += letter;
+                escapeFlag = false;
+            } else if (letter === '\\') {
+                escapeFlag = true;
+            } else if (letter === separator) {
+                result.push(token);
+                token = '';
+            } else {
+                token += letter;
+            }
+        });
+        if (token.length > 0) {
+            result.push(token);
+        }
+        return result;
+    }
+
+    /**
+     * Tries to parse the value to a primitive type. It converts "true" and "false" to a boolean, and "2" to a number.
+     * @param value {String} value to parse
+     * @returns {Boolean|Number|String} parsed value
+     */
     function parseValue(value) {
         if (['true', 'false'].indexOf(value) !== -1) {
             return value === 'true';
         }
-
+        // is it float parsable?
         var parsed = parseFloat(value);
-
         if (!isNaN(parsed)) {
             return parsed;
         }
-
         return value;
     }
 
+    /**
+     * Validates whether the line is a comment (prefixed by # or !)
+     * @param line {String} the line
+     * @returns {Boolean} whether the line is a comment
+     */
     function isLineComment(line) {
         return (/^\s*(\#|\!|$)/.test(line)
         );
     }
 
+    /**
+     * Validates whether the line has continuation character (backslash) at end
+     * @param line {String} the line
+     * @returns {Boolean} whether the line is continued on the next line
+     */
     function isLineContinued(line) {
         return (/(\\\\)*\\$/.test(line)
         );
     }
 
+    /**
+     * Parses the line to a key and value
+     * @param line {String} the line
+     * @returns {Array} array with following structure: [line, key, value]
+     */
     function parseLine(line) {
         return (/^\s*((?:[^\s:=\\]|\\.)+)\s*[:=\s]\s*(.*)$/.exec(line)
         );
     }
 
+    /**
+     * Makes a deep structured object from a shallow object with dot-separated keys:
+     *   { "key.with.nesting": "value" }
+     *   becomes:
+     *   { "key": { "with": { "nesting": "value" } } }
+     * @param obj
+     * @returns {{}}
+     */
     function makeDeepStructure(obj) {
         return Object.keys(obj).reduce(function (nested, key) {
             assignProperty(nested, key, obj[key]);
@@ -78,47 +134,68 @@
         }, {});
     }
 
+    /**
+     * Combines lines which end with a backslash with the next line
+     * @param lines {String[]}
+     * @returns {String[]}
+     */
     function combineMultiLines(lines) {
         return lines.reduce(function (acc, cur) {
             var line = acc[acc.length - 1];
-
             if (acc.length && isLineContinued(line)) {
                 acc[acc.length - 1] = line.replace(/\\$/, '');
                 acc[acc.length - 1] += cur;
             } else {
                 acc.push(cur);
             }
-
             return acc;
         }, []);
     }
 
+    /**
+     * Removes leading white-space of every line
+     * @param lines {String[]}
+     * @returns {String[]}
+     */
     function removeLeadingWhitespace(lines) {
         return lines.map(function (line) {
             return line.replace(/^\s*/, '');
-        });
+        }); // remove space at start of line
     }
 
+    /**
+     * Filters out the comment lines
+     * @param lines {String[]}
+     * @returns {String[]}
+     */
     function filterOutComments(lines) {
         return lines.filter(function (line) {
             return !isLineComment(line);
         });
     }
 
+    /**
+     * Parses the lines add adds the key-values to the return object
+     * @param lines {String[]}
+     * @returns {{}} the parsed key-value pairs
+     */
     function parseLines(lines) {
         var propertyMap = {};
         lines.forEach(function (line) {
             var parsed = parseLine(line);
-
             if (!parsed) {
                 throw new Error('Cannot parse line: ', line);
             }
-
             propertyMap[parsed[1]] = parsed[2];
         });
         return propertyMap;
     }
 
+    /**
+     * Loops over the object values and tries to parse them to a native value.
+     * @param obj
+     * @returns {Object} the same object as the argument
+     */
     function parseValues(obj) {
         Object.keys(obj).forEach(function (key) {
             obj[key] = parseValue(obj[key]);
@@ -126,6 +203,11 @@
         return obj;
     }
 
+    /**
+     * Makes an array of strings from a string containing return-characters.
+     * @param str
+     * @returns {Array} array of lines
+     */
     function makeLines(str) {
         return str.split(/\r?\n/);
     }

--- a/example/tonic.js
+++ b/example/tonic.js
@@ -7,6 +7,8 @@ user.followers.title.other  = All {{count}} Followers\n\
 button.add_user.title       = Add a user\n\
 button.add_user.text        = Add\n\
 button.add_user.disabled    = Saving...\n\
+button.dict.fo\\\\o         = should have a backslash\n\
+button.dict.bar\\.bar       = should have a dot\n\
 # You can add comments like this,\n\
     ! or with comments\n\
     longvalue                   = You can even use \\\n\

--- a/lib/java.properties.js
+++ b/lib/java.properties.js
@@ -11,7 +11,7 @@ function compose() {
 }
 
 function assignProperty(obj, path, value) {
-    const props = path.split('.');
+    const props = splitEscaped(path, '.');
     const key = props.pop();
     obj = props.reduce((newObj, prop) => {
         if (!newObj[prop]) {
@@ -24,6 +24,36 @@ function assignProperty(obj, path, value) {
 }
 
 /**
+ * Split a string using a separator, if not preceded by a backslash.
+ * For simplicity, this does not correctly handle two preceding backslashes
+ * @param src {String} value to parse
+ * @param separator {String} single character separator
+ * @returns []
+ */
+function splitEscaped(src, separator) {
+    let escapeFlag = false,
+        token = '',
+        result = [];
+    src.split('').forEach(letter => {
+        if (escapeFlag) {
+            token += letter;
+            escapeFlag = false;
+        } else if (letter === '\\') {
+            escapeFlag = true;
+        } else if (letter === separator) {
+            result.push(token);
+            token = '';
+        } else {
+            token += letter;
+        }
+    });
+    if (token.length > 0) {
+        result.push(token);
+    }
+    return result;
+}
+
+/**
  * Tries to parse the value to a primitive type. It converts "true" and "false" to a boolean, and "2" to a number.
  * @param value {String} value to parse
  * @returns {Boolean|Number|String} parsed value
@@ -32,7 +62,7 @@ function parseValue(value) {
     if (['true', 'false'].includes(value)) {
         return value === 'true';
     }
-    // is it float parseble?
+    // is it float parsable?
     const parsed = parseFloat(value);
     if (!isNaN(parsed)) {
         return parsed;

--- a/test/java.properties.js
+++ b/test/java.properties.js
@@ -73,3 +73,10 @@ test('it should handle special characters correctly', (assert) => {
 
     assert.end();
 });
+
+test('it should handle escaped dots in the property name', (assert) => {
+    assert.deepEqual(pToO('test\\.test=value'), { 'test.test': 'value' }, 'Escaped dot in key');
+    assert.deepEqual(pToO('test\\\\test=value'), { 'test\\test': 'value' }, 'Escaped backslash in key');
+    assert.deepEqual(pToO('test\\test=value'), { 'testtest': 'value' }, 'Escaped normal character in key');
+    assert.end();
+});


### PR DESCRIPTION
Allow property keys such as:
`button.dict.fo\\o         = should have a backslash`
`button.dict.bar\.bar       = should have a dot`