### PR TITLE
added replacement of escaped unicode characters e.g. \u00A9 to ©

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,9 @@ user.followers.title.other  = All {{count}} Followers
 button.add_user.title       = Add a user
 button.add_user.text        = Add
 button.add_user.disabled    = Saving...
+# Unicode characters are processed (e.g. '© or ü or ß' see below)
+unicode.chars               = \\u00A9 or \\u00FC or \\u00DF
+
 # You can add comments like this,
 ! or with comments
 longvalue                   = You can even use \

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ button.add_user.title       = Add a user
 button.add_user.text        = Add
 button.add_user.disabled    = Saving...
 # Unicode characters are processed (e.g. '© or ü or ß' see below)
-unicode.chars               = \\u00A9 or \\u00FC or \\u00DF
+unicode.chars               = \u00A9 or \u00FC or \u00DF
 
 # You can add comments like this,
 ! or with comments

--- a/lib/java.properties.js
+++ b/lib/java.properties.js
@@ -67,8 +67,23 @@ function parseValue(value) {
     if (!isNaN(parsed)) {
         return parsed;
     }
-    return value;
-}
+    value = encodeEscapedUnicodeChars(value);
+    return value; 
+} 
+ 
+/** 
+ * @method encodeEscapedUnicodeChars 
+ * @param stringToEncode {String} value to encode (e.g. \u00FD) 
+ * @returns string with  replaced \u<xxxx> sequences OR the original input 
+ */ 
+function encodeEscapedUnicodeChars(stringToEncode) { 
+    if (typeof stringToEncode === 'string') { 
+        return stringToEncode.replace(/\\u[0-9a-fA-F]{4}/g, function(value) { 
+            return JSON.parse('"' + value + '"'); 
+        }); 
+    } 
+    return stringToEncode; 
+}; 
 
 /**
  * Validates whether the line is a comment (prefixed by # or !)

--- a/test/java.properties.js
+++ b/test/java.properties.js
@@ -69,7 +69,7 @@ test('it should parse values with specific type', (assert) => {
 });
 
 test('it should handle special characters correctly', (assert) => {
-    assert.strictEqual(pToO('special=\u00A9 or \u00FC or \u00DF').special, '© or ü or ß', 'Unicode characters should be processed');
+    assert.strictEqual(pToO('special=\\u00A9 or \\u00FC or \\u00DF').special, '© or ü or ß', 'Unicode characters should be processed');
 
     assert.end();
 });


### PR DESCRIPTION
According to https://de.wikipedia.org/wiki/Java-Properties-Datei  the following replacement should work:
```
unicodeText = Ein Smiley: \u263A
```
I fixed the unicode tests and added the missing piece of implementation.